### PR TITLE
Remove langchain_chroma from dependancies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ dependencies=[
 "langchain_anthropic",
 "langchain-together",
 "langchain_core",
-"langchain_chroma",
 "langchain_experimental",
 "e2b-code-interpreter",
 ]


### PR DESCRIPTION
langchain_chroma was causing a dependency conflict with learn-ai. Since the code that uses it is not currently used, i removed it as a package dependancy